### PR TITLE
bump dep versions

### DIFF
--- a/FsGrpc-sln/FsGrpc.slnx
+++ b/FsGrpc-sln/FsGrpc.slnx
@@ -1,3 +1,4 @@
 <Solution>
   <Project Path="../FsGrpc/FsGrpc.fsproj" />
+  <Project Path="../FsGrpc/FsGrpc.Tests/FsGrpc.Tests.fsproj" />
 </Solution>

--- a/FsGrpc-sln/FsGrpc.slnx
+++ b/FsGrpc-sln/FsGrpc.slnx
@@ -1,0 +1,3 @@
+<Solution>
+  <Project Path="../FsGrpc/FsGrpc.fsproj" />
+</Solution>

--- a/FsGrpc/FsGrpc.fsproj
+++ b/FsGrpc/FsGrpc.fsproj
@@ -23,9 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="6.0.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.26.1" />
-    <PackageReference Include="NodaTime" Version="3.1.11" />
+    <PackageReference Update="FSharp.Core" Version="8.0.403" />
+    <PackageReference Include="Google.Protobuf" Version="3.33.1" />
+    <PackageReference Include="NodaTime" Version="3.2.2" />
   </ItemGroup>
 
 </Project>

--- a/FsGrpc/Protobuf.fs
+++ b/FsGrpc/Protobuf.fs
@@ -730,7 +730,7 @@ module ValueCodec =
                     let item = primitive.ReadValue subreader
                     output[i] <- item
                 output |> Seq.toList
-            | Variable _ -> 
+            | Variable -> 
                 let builder = new System.Collections.Generic.List<'P>()
                 let sub = r.ReadBytes()
                 use subreader = sub.CreateCodedInput()


### PR DESCRIPTION
This pull request introduces several updates to the FsGrpc project, including dependency upgrades, a solution file addition, and a minor code fix. The most significant changes are the updates to package dependencies to keep the project current and compatible, and the addition of a solution file for improved project structure.

Dependency upgrades:

* Updated package versions in `FsGrpc.fsproj`: `FSharp.Core` to 8.0.403, `Google.Protobuf` to 3.33.1, and `NodaTime` to 3.2.2, ensuring compatibility with the latest features and bug fixes.

Project structure:

* Added a new solution file `FsGrpc.slnx` to reference the main project, improving organization and IDE support.

Code correctness:

* Fixed pattern matching in the `ValueCodec` module (`Protobuf.fs`) by replacing `Variable _` with `Variable`, improving code clarity and correctness.